### PR TITLE
fix: respect formula_enable parameter in hybrid backend

### DIFF
--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -698,7 +698,7 @@ def do_parse(
                 backend = get_vlm_engine(inference_engine='auto', is_async=False)
 
             os.environ['MINERU_VLM_TABLE_ENABLE'] = str(table_enable)
-            os.environ['MINERU_VLM_FORMULA_ENABLE'] = "true"
+            os.environ['MINERU_VLM_FORMULA_ENABLE'] = str(formula_enable)
 
             _process_hybrid(
                 output_dir, pdf_file_names, pdf_bytes_list, p_lang_list, parse_method, formula_enable, backend,
@@ -790,7 +790,7 @@ async def aio_do_parse(
                 backend = get_vlm_engine(inference_engine='auto', is_async=True)
 
             os.environ['MINERU_VLM_TABLE_ENABLE'] = str(table_enable)
-            os.environ['MINERU_VLM_FORMULA_ENABLE'] = "true"
+            os.environ['MINERU_VLM_FORMULA_ENABLE'] = str(formula_enable)
 
             await _async_process_hybrid(
                 output_dir, pdf_file_names, pdf_bytes_list, p_lang_list, parse_method, formula_enable, backend,


### PR DESCRIPTION
## Motivation

In `mineru/cli/common.py`, the hybrid-* backend (both sync do_parse and async aio_do_parse) hardcoded MINERU_VLM_FORMULA_ENABLE = "true", ignoring the formula_enable parameter passed by the method.

## Modification

In mineru/cli/common.py
Before: os.environ['MINERU_VLM_FORMULA_ENABLE'] = "true" (hardcoded)
After: os.environ['MINERU_VLM_FORMULA_ENABLE'] = str(formula_enable) (uses actual parameter value)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
