### PR TITLE
Fix docx page detection: also split on manual page breaks and pageBreakBefore

### DIFF
--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -1397,6 +1397,18 @@ class DocxConverter:
             else:
                 # 标记本节结束，处理完文本之后再分节
                 is_section_end = True
+
+        # Manual page breaks and pageBreakBefore are page-forcing constructs
+        # this splitter otherwise never sees at all (has_section_break above
+        # only catches Word *section* breaks). pageBreakBefore means THIS
+        # paragraph starts a new page, so it fires immediately; a manual
+        # <w:br w:type="page"/> run defers to end-of-paragraph like
+        # is_section_end (no intra-paragraph pre-break/post-break split is
+        # attempted here).
+        if self._has_page_break_before(element):
+            self._start_new_page()
+        has_manual_page_break = self._has_manual_page_break(element)
+
         paragraph = Paragraph(element, self.docx_obj)
         paragraph_elements = self._get_paragraph_elements(paragraph)
         paragraph_text = self._get_paragraph_text(paragraph)
@@ -1421,6 +1433,8 @@ class DocxConverter:
                 self._close_active_list()
             # 普通 TOC 段落被转换为 INDEX 后，也要保留段落末尾分节分页语义。
             if is_section_end:
+                self._start_new_page()
+            if has_manual_page_break and not is_section_end:
                 self._start_new_page()
             return None
         self._reset_index_state()
@@ -1595,6 +1609,8 @@ class DocxConverter:
                 self.cur_page.append(text_block)
 
         if is_section_end:
+            self._start_new_page()
+        if has_manual_page_break and not is_section_end:
             self._start_new_page()
 
     def _handle_pictures(self, picture_refs: Any):
@@ -2200,6 +2216,29 @@ class DocxConverter:
         if pPr is None:
             return None
         return pPr.find(child_tag, namespaces=namespaces)
+
+    def _has_page_break_before(self, element: BaseOxmlElement) -> bool:
+        """
+        True if this paragraph's pPr has <w:pageBreakBefore/> and it isn't
+        explicitly disabled via w:val="0"/"false"/"off" (OOXML boolean-toggle
+        convention: presence alone means true, an explicit falsy w:val means
+        the property is turned off, not a break).
+        """
+        pbb = self._get_paragraph_property_child(element, "w:pageBreakBefore")
+        if pbb is None:
+            return False
+        w_ns = DocxConverter._BLIP_NAMESPACES["w"]
+        val = pbb.get(f"{{{w_ns}}}val")
+        return val not in ("0", "false", "off")
+
+    def _has_manual_page_break(self, element: BaseOxmlElement) -> bool:
+        """True if this paragraph contains a manual page-break run (Ctrl+Enter)."""
+        return (
+            element.find(
+                ".//w:br[@w:type='page']", namespaces=DocxConverter._BLIP_NAMESPACES
+            )
+            is not None
+        )
 
     def _get_effective_numPr(
         self, paragraph: Paragraph

--- a/tests/unittest/test_docx_page_breaks.py
+++ b/tests/unittest/test_docx_page_breaks.py
@@ -1,0 +1,69 @@
+# Copyright (c) Opendatalab. All rights reserved.
+"""
+Regression test for docx page-break detection.
+
+DocxConverter's page splitting previously only fired on Word *section*
+breaks (<w:sectPr>) — manual page breaks (<w:br w:type="page"/>, inserted via
+Word's "Insert > Page Break" / Ctrl+Enter) and the pageBreakBefore paragraph
+property were never inspected, so any docx built with manual breaks instead
+of section breaks collapsed to a single page regardless of its real length.
+"""
+from io import BytesIO
+
+from docx import Document
+
+from mineru.model.docx.main import convert_binary
+
+
+def _build_repro_docx() -> bytes:
+    doc = Document()
+    doc.add_paragraph("Page 0 content")
+
+    for i in range(1, 4):
+        doc.add_page_break()  # <w:br w:type="page"/>
+        doc.add_paragraph(f"Page {i} content (manual page break)")
+
+    p = doc.add_paragraph("Page 4 content (pageBreakBefore)")
+    p.paragraph_format.page_break_before = True
+
+    buf = BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def test_manual_page_breaks_and_page_break_before_split_pages():
+    docx_bytes = _build_repro_docx()
+    pages = convert_binary(BytesIO(docx_bytes))
+
+    # 1 initial page + 3 manual <w:br w:type="page"/> breaks + 1
+    # pageBreakBefore paragraph = 5 pages, even though this document has
+    # zero <w:sectPr> section breaks.
+    assert len(pages) == 5
+
+
+def test_disabled_page_break_before_does_not_split():
+    doc = Document()
+    doc.add_paragraph("Page 0 content")
+    p = doc.add_paragraph("Still page 0 — property explicitly disabled")
+    p.paragraph_format.page_break_before = False
+
+    buf = BytesIO()
+    doc.save(buf)
+    pages = convert_binary(BytesIO(buf.getvalue()))
+
+    assert len(pages) == 1
+
+
+def test_plain_line_break_does_not_split():
+    # A soft line break (<w:br/> with no w:type, or w:type="textWrapping")
+    # must not be mistaken for a manual page break.
+    doc = Document()
+    p = doc.add_paragraph("Line one")
+    p.add_run().add_break()  # plain <w:br/>, no type -> textWrapping
+    p.add_run("Line two")
+
+    buf = BytesIO()
+    doc.save(buf)
+    pages = convert_binary(BytesIO(buf.getvalue()))
+
+    assert len(pages) == 1


### PR DESCRIPTION
## Motivation

`DocxConverter._handle_text_elements()` only calls `_start_new_page()` on a Word section break (`<w:sectPr>`). Manual page breaks (`<w:br w:type="page"/>`, inserted via Word's "Insert > Page Break" / Ctrl+Enter) and the `pageBreakBefore` paragraph property are never inspected at all, so a docx authored with manual breaks instead of section breaks collapses every content_list element to `page_idx=0`, regardless of how many real pages the document has.

Found this on a real docx file: 51 manual page breaks, 0 section breaks — all 574 elements came back on page 0, silently producing wrong page numbers for anything built on top of `content_list.json`'s `page_idx` (e.g. citation/page-reference features).

## Modification

Adds two helpers, `_has_page_break_before` and `_has_manual_page_break`, and wires them into the existing `has_section_break`/`is_section_end` flow in `_handle_text_elements`:

- `pageBreakBefore` fires `_start_new_page()` immediately (before the paragraph's own content is processed), since the property means "this paragraph itself starts a new page" — respecting the OOXML convention that an explicit `w:val="0"/"false"/"off"` means the property is turned off, not a break.
- A manual `<w:br w:type="page"/>` run defers the new page to end-of-paragraph, mirroring how `is_section_end` already works at both its existing call sites — no intra-paragraph pre-break/post-break split is attempted, since `_handle_text_elements` operates at paragraph granularity throughout the rest of the file.

## BC-breaking (Optional)

Not breaking, but a behavior change worth flagging: documents that contain manual page breaks or `pageBreakBefore` — whether alone or mixed with section breaks — will now produce more/different page splits, since those constructs were previously silently ignored. This is a strict correctness improvement (page structure now reflects the real document), but any downstream code relying on the old (wrong) page count for such documents will see it change. Documents using only section breaks, with no manual breaks or `pageBreakBefore` anywhere, are unaffected.

## Use cases (Optional)

Any docx built with manual page breaks instead of (or in addition to) section breaks, now gets correct, distinct `page_idx` values per page instead of everything collapsing onto page 0.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. (`tests/unittest/test_docx_page_breaks.py` — verified to fail against unpatched `main` with `1 == 5`, and pass with this fix.)
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
