### PR TITLE
fix(markdown): escape leading block-quote and ordered-list markers in text blocks

### DIFF
--- a/mineru/backend/utils/markdown_utils.py
+++ b/mineru/backend/utils/markdown_utils.py
@@ -5,8 +5,17 @@ from html import escape
 
 CONSERVATIVE_MARKDOWN_SPECIAL_CHARS = ("*", "_", "`", "~", "$")
 TEXT_BLOCK_MARKDOWN_PREFIX_RE = re.compile(
-    r"^(?P<indent>[ \t]{0,3})(?P<marker>#{1,6}|[+-])(?=[ \t])"
+    r"^(?P<indent>[ \t]{0,3})"
+    r"(?:"
+    r"(?P<marker>#{1,6}|[+-])(?=[ \t])"
+    r"|(?P<quote>>)"
+    r"|\d{1,9}(?P<ordered>[.)])(?=[ \t])"
+    r")"
 )
+# The backslash goes in front of whichever group matched: for an ordered list
+# the digits must stay unescaped, because `\1.` is not a Markdown escape while
+# `1\.` is.
+TEXT_BLOCK_MARKDOWN_PREFIX_GROUPS = ("marker", "quote", "ordered")
 
 
 def escape_conservative_markdown_text(content: str) -> str:
@@ -44,7 +53,11 @@ def escape_text_block_markdown_prefix(content: str) -> str:
     if not match:
         return content
 
-    marker_start = match.start("marker")
+    marker_start = next(
+        match.start(group)
+        for group in TEXT_BLOCK_MARKDOWN_PREFIX_GROUPS
+        if match.group(group) is not None
+    )
     return f"{content[:marker_start]}\\{content[marker_start:]}"
 
 

--- a/tests/unittest/test_text_block_markdown_prefix.py
+++ b/tests/unittest/test_text_block_markdown_prefix.py
@@ -1,0 +1,46 @@
+# Copyright (c) Opendatalab. All rights reserved.
+
+import pytest
+
+from mineru.backend.utils.markdown_utils import escape_text_block_markdown_prefix
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        # Block quote: CommonMark does not require a space after ">".
+        ("> 5 mV was measured at the gate.", "\\> 5 mV was measured at the gate."),
+        (">5 mV was measured at the gate.", "\\>5 mV was measured at the gate."),
+        ("  > up to three spaces of indent still count", "  \\> up to three spaces of indent still count"),
+        # Ordered list: the backslash goes before the delimiter, since "\1." is
+        # not a Markdown escape but "1\." is.
+        ("1. Smith, J. et al. Nature 2020.", "1\\. Smith, J. et al. Nature 2020."),
+        ("2) Second numbered reference.", "2\\) Second numbered reference."),
+        ("1986. A landmark year for the field.", "1986\\. A landmark year for the field."),
+        # Already covered before this change.
+        ("## Section title", "\\## Section title"),
+        ("- bullet item", "\\- bullet item"),
+        ("+ bullet item", "\\+ bullet item"),
+    ],
+)
+def test_leading_block_marker_is_escaped(content, expected):
+    assert escape_text_block_markdown_prefix(content) == expected
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",
+        "Plain sentence with no marker.",
+        # No space after the delimiter, so this is not an ordered list.
+        "1.5 mm is the tolerance.",
+        # CommonMark caps an ordered list marker at nine digits.
+        "1234567890. ten digits is not a list marker",
+        # The marker has to be at the start of the block.
+        "100 > 50 in this comparison",
+        # Four or more leading spaces is an indented code block, not our concern.
+        "     > deeply indented",
+    ],
+)
+def test_text_without_a_block_marker_is_untouched(content):
+    assert escape_text_block_markdown_prefix(content) == content


### PR DESCRIPTION
## Problem

`escape_text_block_markdown_prefix()` exists to stop an assembled plain-text paragraph from being reinterpreted as a different Markdown block. Today its regex only covers ATX headings and `+`/`-` bullets:

```python
r"^(?P<indent>[ \t]{0,3})(?P<marker>#{1,6}|[+-])(?=[ \t])"
```

Two block markers of the same class are missing, so a `BlockType.TEXT` paragraph that happens to start with one is silently promoted to a quote or a list. The three call sites are `pipeline_middle_json_mkcontent.py:301`, `vlm_middle_json_mkcontent.py:357` and `office/mkcontent/inline_renderer.py:964` — all guarded on plain text blocks, so real lists are unaffected.

Rendering the current output through CommonMark (`markdown-it`) on master `79d6d8d`:

| paragraph text | renders today as |
|---|---|
| `> 5 mV was measured at the gate.` | `<blockquote><p>5 mV was measured at the gate.</p></blockquote>` |
| `1. Smith, J. et al. Nature 2020.` | `<ol><li>Smith, J. et al. Nature 2020.</li></ol>` |
| `2) Second numbered reference.` | `<ol start="2"><li>…</li></ol>` |
| `1986. A landmark year for the field.` | `<ol start="1986"><li>…</li></ol>` |

The ordered-list case is the more damaging one in practice: numbered references and enumerations are everywhere in extracted PDFs, and the leading number is swallowed into the list marker, so it disappears from the text entirely.

## Fix

Add the two missing markers to the same regex:

- **Block quote `>`** — note CommonMark does *not* require a space after `>`, so this branch carries no `(?=[ \t])` lookahead, unlike the others.
- **Ordered list `\d{1,9}` followed by `.` or `)`** — capped at nine digits, per CommonMark.

One subtlety: the backslash cannot simply go at the marker start for ordered lists. `\1.` is not a Markdown escape (backslash escapes only apply to ASCII punctuation), so the backslash would render literally. The escape has to be `1\.`. The fix therefore records which alternative matched and inserts the backslash in front of that group.

After the change, all four rows above render as ordinary paragraphs with the leading text intact.

## Verification

Added `tests/unittest/test_text_block_markdown_prefix.py` (15 parametrized cases).

- Against this branch: **15 passed**.
- Against master's `markdown_utils.py`: **6 failed, 9 passed** — the 6 failures are exactly the new quote/ordered-list cases, and the 9 passes are the regression guards, confirming existing behaviour is untouched.

The regression guards cover: existing `#`/`+`/`-` handling, empty input, plain sentences, `1.5 mm` (no space after the delimiter, so not a list), a ten-digit run (over the CommonMark cap), `>` appearing mid-line, and four-space indentation (an indented code block, out of scope here).

I kept this to the two missing block markers and deliberately did not touch setext underlines or `---` thematic breaks — those are multi-line concerns that this block-prefix helper cannot see.

No conflict with #5364: that PR changes `CONSERVATIVE_MARKDOWN_SPECIAL_CHARS` and adds `tests/unittest/test_markdown_utils.py`, while this one changes `TEXT_BLOCK_MARKDOWN_PREFIX_RE` and adds a separate test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
