### PR TITLE
fix(mlx): tolerate invalid UTF-8 VLM tokens

### DIFF
--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -35,6 +35,7 @@ from ...utils.pdfium_guard import (
     open_pdfium_document,
 )
 from ...utils.models_download_utils import auto_download_and_get_model_root_path
+from ...utils.mlx_vlm_compat import patch_mlx_vlm_utf8_decoder
 
 from mineru_vl_utils import MinerUClient
 from packaging import version
@@ -109,6 +110,8 @@ class ModelSingleton:
                     mlx_supported = is_mac_os_version_supported()
                     if not mlx_supported:
                         raise EnvironmentError("mlx-engine backend is only supported on macOS 13.5+ with Apple Silicon.")
+                    if patch_mlx_vlm_utf8_decoder():
+                        logger.info("Applied mlx-vlm UTF-8 streaming compatibility patch")
                     from mineru_vl_utils.mlx_compat import load_mlx_model
                     model, processor = load_mlx_model(model_path)
                 else:

--- a/mineru/utils/mlx_vlm_compat.py
+++ b/mineru/utils/mlx_vlm_compat.py
@@ -1,0 +1,44 @@
+"""Compatibility patches for optional MLX VLM dependencies."""
+
+import inspect
+from typing import Any
+
+
+def patch_mlx_vlm_utf8_decoder() -> bool:
+    """Backport the MLX VLM UTF-8 streaming fix for older releases."""
+    try:
+        from mlx_vlm import tokenizer_utils
+    except ImportError:
+        return False
+
+    detokenizer = tokenizer_utils.BPEStreamingDetokenizer
+    try:
+        source = inspect.getsource(detokenizer.add_token)
+    except (OSError, TypeError):
+        return False
+
+    if "errors=\"replace\"" in source or "errors=\x27replace\x27" in source:
+        return False
+
+    def add_token(
+        self: Any,
+        token: int,
+        skip_special_token_ids: list[int] = [],
+    ) -> None:
+        if token in skip_special_token_ids:
+            return
+        value = self.tokenmap[token]
+        if self._byte_decoder[value[0]] == 32:
+            current_text = bytearray(
+                self._byte_decoder[char] for char in self._unflushed
+            ).decode("utf-8", errors="replace")
+            if self.text or not self.trim_space:
+                self.text += current_text
+            else:
+                self.text += tokenizer_utils._remove_space(current_text)
+            self._unflushed = value
+        else:
+            self._unflushed += value
+
+    detokenizer.add_token = add_token
+    return True

--- a/tests/unittest/test_mlx_vlm_compat.py
+++ b/tests/unittest/test_mlx_vlm_compat.py
@@ -1,0 +1,65 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from mineru.utils import mlx_vlm_compat
+
+
+class FakeDetokenizer:
+    _byte_decoder = {"x": 0x8D, "s": 32}
+
+    def __init__(self) -> None:
+        self.tokenmap = ["x", "s"]
+        self._unflushed = ""
+        self.text = ""
+        self.trim_space = False
+
+    def add_token(self, token: int, skip_special_token_ids: list[int] = []) -> None:
+        if token in skip_special_token_ids:
+            return
+        value = self.tokenmap[token]
+        if self._byte_decoder[value[0]] == 32:
+            current_text = bytearray(
+                self._byte_decoder[char] for char in self._unflushed
+            ).decode("utf-8")
+            self.text += current_text
+            self._unflushed = value
+        else:
+            self._unflushed += value
+
+
+def test_backports_mlx_vlm_utf8_replacement_decoder() -> None:
+    tokenizer_utils = SimpleNamespace(
+        BPEStreamingDetokenizer=FakeDetokenizer,
+        _remove_space=lambda value: value.removeprefix(" "),
+    )
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.tokenizer_utils = tokenizer_utils
+
+    with patch.dict(sys.modules, {"mlx_vlm": mlx_vlm}):
+        with patch.object(mlx_vlm_compat.inspect, "getsource", return_value="strict"):
+            assert mlx_vlm_compat.patch_mlx_vlm_utf8_decoder()
+
+    decoder = FakeDetokenizer()
+    decoder.add_token(0)
+    decoder.add_token(1)
+
+    assert decoder.text == "\ufffd"
+
+
+def test_skips_mlx_vlm_versions_with_the_upstream_fix() -> None:
+    tokenizer_utils = SimpleNamespace(BPEStreamingDetokenizer=FakeDetokenizer)
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.tokenizer_utils = tokenizer_utils
+    original_add_token = FakeDetokenizer.add_token
+
+    with patch.dict(sys.modules, {"mlx_vlm": mlx_vlm}):
+        with patch.object(
+            mlx_vlm_compat.inspect,
+            "getsource",
+            return_value="errors=" + chr(34) + "replace" + chr(34),
+        ):
+            assert not mlx_vlm_compat.patch_mlx_vlm_utf8_decoder()
+
+    assert FakeDetokenizer.add_token is original_add_token


### PR DESCRIPTION
## Motivation

Older `mlx-vlm` releases strictly decode the pending byte-level BPE buffer. A generated byte-fallback token followed by a space-prefixed token can raise `UnicodeDecodeError` and abort the full MinerU VLM task.

## Modification

- Backport the upstream replacement-decoding behavior for older `mlx-vlm` releases at MLX engine initialization.
- Leave releases that already use `errors="replace"` unchanged.
- Add focused regression coverage for both paths.

## Validation

- Focused Ruff check passes for the new compatibility module and regression test.
- Regression tests pass: `2 passed`.
- Verified a one-page Hybrid MLX parse on macOS with MinerU 3.4.4, `mlx-vlm 0.3.9`, `mlx 0.31.1`, and `transformers 4.57.6`.

## BC-breaking

No. The patch only prevents an MLX VLM generation crash; non-MLX backends and already-fixed `mlx-vlm` versions are unchanged.

This branch is based on the locally tested Git commit. The earlier web-editor PRs were closed because their new files had incorrect nested paths.